### PR TITLE
feat: [CO-659] control antivirus scan with carbonioAmavisDisableVirusCheck

### DIFF
--- a/conf/amavisd.conf.in
+++ b/conf/amavisd.conf.in
@@ -9,7 +9,7 @@ use strict;
 
 # COMMONLY ADJUSTED SETTINGS:
 
-#@bypass_virus_checks_maps = (1);  # uncomment to DISABLE anti-virus code
+%%uncomment VAR:carbonioAmavisDisableVirusCheck%% @bypass_virus_checks_maps = (1);  # uncomment to DISABLE anti-virus code
 %%comment SERVICE:antispam%% @bypass_spam_checks_maps  = (1);  # uncomment to DISABLE anti-spam code
 # $bypass_decode_parts = 1;         # controls running of decoders&dearchivers
 


### PR DESCRIPTION
**What has changed:**

- use carbonioAmavisDisableVirusCheck server attribute to enable disable antivirus scan feature of amavis
- The mapping works in this way:
    -  carbonioAmavisDisableVirusCheck FALSE -> line commented -> scan enabled
    -  carbonioAmavisDisableVirusCheck TRUE -> line not commented -> scan disabled


**Related PRs:**
- https://github.com/Zextras/carbonio-mailbox/pull/189