### PR TITLE
feat: [CO-825] make use of local clamAv if available as backup scanner

### DIFF
--- a/conf/amavisd.conf.in
+++ b/conf/amavisd.conf.in
@@ -819,6 +819,12 @@ $banned_filename_re = new_RE(
 
 @av_scanners_backup = (
 
+# fallback to local socket(if available) when all other scanners failed.
+  ['ClamAV-clamd',
+   \&ask_daemon, ["CONTSCAN {}\n", '/opt/zextras/data/clamav/clamav.sock'],
+   qr/\bOK$/m, qr/\bFOUND$/m,
+   qr/^.*?: (?!Infected Archive)(.*) FOUND$/m ],
+
   ### http://www.clamav.net/   - backs up clamd or Mail::ClamAV
   ['ClamAV-clamscan', 'clamscan',
     "--stdout --no-summary -r --tempdir=$TEMPBASE {}",


### PR DESCRIPTION
**What has changed:**
Amavisd will be able to utilize local clamav(if present) for scanning emails if the remote one fails due to random issues like socket timeouts etc.

**Related PRs:**
- https://github.com/zextras/carbonio-mailbox/pull/355
- https://github.com/zextras/carbonio-mta/pull/8
- https://github.com/zextras/carbonio-ldap-utilities/pull/58