### PR TITLE
fix: config: add Listen on localhost IPV4

### DIFF
--- a/conf/amavisd.conf.in
+++ b/conf/amavisd.conf.in
@@ -81,6 +81,9 @@ $enable_dkim_signing = 0;    # load DKIM signing code, keys defined by dkim_key
 #$inet_socket_port = [10024,10026];   # listen on this local TCP port(s)
 # $inet_socket_port = [10024,10026];  # listen on multiple TCP ports
 
+#Listen on localhost IPV4 
+$inet_socket_bind = '127.0.0.1';
+
 $policy_bank{'MYNETS'} = {   # mail originating from @mynetworks
   originating => 1,  # is true in MYNETS by default, but let's make it explicit
   os_fingerprint_method => undef,  # don't query p0f for internal clients


### PR DESCRIPTION
On hosts with ipv6 enabled amavis fails to start, I added a row in the conf that forces it to liste on localhost ipv4
